### PR TITLE
Parallel hash generation

### DIFF
--- a/imagededup/evaluation/evaluation.py
+++ b/imagededup/evaluation/evaluation.py
@@ -11,6 +11,7 @@ from imagededup.utils.logger import return_logger
 
 logger = return_logger(__name__, os.getcwd())
 
+
 def _transpose_checker(mapping):
     """
     Check for the given dictionary that transpose relationship holds.
@@ -109,4 +110,5 @@ def evaluate(
         return ir_metrics
     else:
         raise ValueError(
-            'Acceptable metrics are: \'map\', \'ndcg\', \'jaccard\', \'classification\', \'all\'')
+            'Acceptable metrics are: \'map\', \'ndcg\', \'jaccard\', \'classification\', \'all\''
+        )

--- a/imagededup/handlers/metrics/classification.py
+++ b/imagededup/handlers/metrics/classification.py
@@ -92,7 +92,10 @@ def classification_metrics(ground_truth: Dict, retrieved: Dict) -> np.ndarray:
         all_pairs, ground_truth_duplicate_pairs, retrieved_duplicate_pairs
     )
     print(classification_report(y_true, y_pred))
-    prec_rec_fscore_support = dict(zip(('precision', 'recall', 'f1_score', 'support'),
-                               precision_recall_fscore_support(y_true, y_pred)))
+    prec_rec_fscore_support = dict(
+        zip(
+            ('precision', 'recall', 'f1_score', 'support'),
+            precision_recall_fscore_support(y_true, y_pred),
+        )
+    )
     return prec_rec_fscore_support
-

--- a/imagededup/handlers/search/bktree.py
+++ b/imagededup/handlers/search/bktree.py
@@ -9,7 +9,10 @@ class BkTreeNode:
     """
     Class to contain the attributes of a single node in the BKTree.
     """
-    def __init__(self, node_name: str, node_value: str, parent_name: str = None) -> None:
+
+    def __init__(
+        self, node_name: str, node_value: str, parent_name: str = None
+    ) -> None:
         self.node_name = node_name
         self.node_value = node_value
         self.parent_name = parent_name
@@ -20,6 +23,7 @@ class BKTree:
     """
     Class to construct and perform search using a BKTree.
     """
+
     def __init__(self, hash_dict: Dict, distance_function: FunctionType) -> None:
         """
         Initialize a root for the BKTree and triggers the tree construction using the dictionary for mapping file names
@@ -49,12 +53,19 @@ class BKTree:
         Return:
             0 for successful execution.
         """
-        dist_current_node = self.distance_function(self.hash_dict[k], self.dict_all[current_node].node_value)
-        condition_insert_current_node_child = (not self.dict_all[current_node].children) or (dist_current_node not in
-                                                                   list(self.dict_all[current_node].children.values()))
+        dist_current_node = self.distance_function(
+            self.hash_dict[k], self.dict_all[current_node].node_value
+        )
+        condition_insert_current_node_child = (
+            not self.dict_all[current_node].children
+        ) or (
+            dist_current_node not in list(self.dict_all[current_node].children.values())
+        )
         if condition_insert_current_node_child:
             self.dict_all[current_node].children[k] = dist_current_node
-            self.dict_all[k] = BkTreeNode(k, self.hash_dict[k], parent_name=current_node)
+            self.dict_all[k] = BkTreeNode(
+                k, self.hash_dict[k], parent_name=current_node
+            )
         else:
             for i, val in self.dict_all[current_node].children.items():
                 if val == dist_current_node:
@@ -70,7 +81,9 @@ class BKTree:
         for k in self.all_keys:
             self._insert_in_tree(k, self.ROOT)
 
-    def _get_next_candidates(self, query: str, candidate_obj: BkTreeNode, tolerance: int) -> Tuple[list, int, float]:
+    def _get_next_candidates(
+        self, query: str, candidate_obj: BkTreeNode, tolerance: int
+    ) -> Tuple[list, int, float]:
         """
         Get candidates for checking if the query falls within the distance tolerance. Sets a validity flag if the input
         candidate BKTree node is valid (distance to this candidate is within the distance tolerance from the query.)
@@ -91,7 +104,11 @@ class BKTree:
             validity = 0
         search_range_dist = list(range(dist - tolerance, dist + tolerance + 1))
         candidate_children = candidate_obj.children
-        candidates = [k for k in candidate_children.keys() if candidate_children[k] in search_range_dist]
+        candidates = [
+            k
+            for k in candidate_children.keys()
+            if candidate_children[k] in search_range_dist
+        ]
         return candidates, validity, dist
 
     def search(self, query: str, tol: int = 5) -> Dict:
@@ -110,9 +127,13 @@ class BKTree:
         candidates_local = copy.deepcopy(self.candidates)
         while len(candidates_local) != 0:
             candidate_name = candidates_local.pop()
-            cand_list, valid_flag, dist = self._get_next_candidates(query, self.dict_all[candidate_name], tolerance=tol)
+            cand_list, valid_flag, dist = self._get_next_candidates(
+                query, self.dict_all[candidate_name], tolerance=tol
+            )
             if valid_flag:
-                valid_retrievals.append((candidate_name, int(dist)))  # typecast dist to int to save later as np.int64
+                valid_retrievals.append(
+                    (candidate_name, int(dist))
+                )  # typecast dist to int to save later as np.int64
                 # can't be saved by json
             candidates_local.extend(cand_list)
         return valid_retrievals

--- a/imagededup/handlers/search/brute_force.py
+++ b/imagededup/handlers/search/brute_force.py
@@ -6,6 +6,7 @@ class BruteForce:
     """
     Class to perform search using a Brute force.
     """
+
     def __init__(self, hash_dict: Dict, distance_function: FunctionType) -> None:
         """
         Initialize a dictionary for mapping file names and corresponding hashes anda  distance function to be used for
@@ -29,6 +30,8 @@ class BruteForce:
         Returns:
             List of tuples of the form [(valid_retrieval_filename1: distance), (valid_retrieval_filename2: distance)]
         """
-        return [(item, self.distance_function(query, self.hash_dict[item])) for item in self.hash_dict if
-                self.distance_function(query, self.hash_dict[item]) <= tol]
-
+        return [
+            (item, self.distance_function(query, self.hash_dict[item]))
+            for item in self.hash_dict
+            if self.distance_function(query, self.hash_dict[item]) <= tol
+        ]

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -1,5 +1,4 @@
-from types import FunctionType
-from typing import Dict, Union
+from typing import Dict, Union, Callable
 
 from imagededup.handlers.search.bktree import BKTree
 from imagededup.handlers.search.brute_force import BruteForce
@@ -11,7 +10,7 @@ class HashEval:
         self,
         test: Dict,
         queries: Dict,
-        distance_function: FunctionType,
+        distance_function: Callable,
         threshold: int = 5,
         search_method: str = 'bktree',
     ) -> None:

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -5,16 +5,19 @@ from types import FunctionType
 from imagededup.utils.logger import return_logger
 from imagededup.handlers.search.bktree import BKTree
 from imagededup.handlers.search.brute_force import BruteForce
-<<<<<<< HEAD
-=======
+
 from imagededup.utils.logger import return_logger
 from types import FunctionType
 from numpy.linalg import norm
 from typing import Tuple, Dict, List, Union
 import os
 import numpy as np
+
 from imagededup.utils.general_utils import parallelize
->>>>>>> Add multiprocessing for retrieval.
+
+
+from imagededup.utils.general_utils import parallelise
+
 
 
 class HashEval:
@@ -43,10 +46,9 @@ class HashEval:
         else:
             self._fetch_nearest_neighbors_brute_force()
 
-    def _searcher(self, result_map: Dict, search_method_object, query_list: List) -> None:
+    def _searcher(self, query_list: List) -> None:
         """
         Perform image encoding on a sublist passed in by encode_images multiprocessing part.
-
         Args:
             hash_dict: Global dictionary that gets shared by all processes
             filenames: Sublist of file names on which hashes are to be generated.
@@ -67,9 +69,20 @@ class HashEval:
         Args:
             search_method_object: BruteForce or BKTree object to get results for the query.
         """
-        result_map = parallelize(target_function=self._searcher, all_tasks=list(self.queries.keys()),
-                                 args_target_function=(search_method_object,))
+        result_map = {}
 
+        # hashes = parallelise(self._searcher, files)
+        # hash_initial_dict = dict(zip([f.name for f in files], hashes))
+        # hash_dict = {k: v for k, v in hash_initial_dict.items() if v}
+
+        for each in self.queries:
+            res = search_method_object.search(
+                query=self.queries[each], tol=self.threshold
+            )  # list of tuples
+            res = [i for i in res if i[0] != each]  # to avoid self retrieval
+            result_map[each] = res
+
+        # result_map = parallelise()
         self.query_results_map = {
             k: [i for i in sorted(v, key=lambda tup: tup[1], reverse=False)]
             for k, v in result_map.items()

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -15,9 +15,6 @@ import numpy as np
 from imagededup.utils.general_utils import parallelise
 
 
-from imagededup.utils.general_utils import parallelise
-
-
 class HashEval:
     def __init__(
         self,

--- a/imagededup/handlers/search/retrieval.py
+++ b/imagededup/handlers/search/retrieval.py
@@ -40,9 +40,7 @@ class HashEval:
            List of retrieved duplicate files and corresponding hamming distance for the query file.
         """
         query_key, query_val, search_method_object, thresh = data_tuple
-        res = search_method_object.search(
-            query=query_val, tol=thresh
-        )
+        res = search_method_object.search(query=query_val, tol=thresh)
         res = [i for i in res if i[0] != query_key]  # to avoid self retrieval
         return res
 
@@ -55,9 +53,14 @@ class HashEval:
         Args:
             search_method_object: BruteForce or BKTree object to get results for the query.
         """
-        args = list(zip(list(self.queries.keys()), list(self.queries.values()),
-                                                           [search_method_object]*len(self.queries),
-                                                           [self.threshold]*len(self.queries)))
+        args = list(
+            zip(
+                list(self.queries.keys()),
+                list(self.queries.values()),
+                [search_method_object] * len(self.queries),
+                [self.threshold] * len(self.queries),
+            )
+        )
         result_map_list = parallelise(self._searcher, args)
         result_map = dict(zip(list(self.queries.keys()), result_map_list))
 

--- a/imagededup/methods/cnn.py
+++ b/imagededup/methods/cnn.py
@@ -9,10 +9,6 @@ from imagededup.utils.general_utils import save_json, get_files_to_remove
 from imagededup.utils.image_utils import load_image, preprocess_image
 from imagededup.utils.logger import return_logger
 
-from imagededup.utils.general_utils import save_json, get_files_to_remove
-from sklearn.metrics.pairwise import cosine_similarity
-from imagededup.utils.general_utils import parallelize
-
 
 class CNN:
     """
@@ -234,29 +230,6 @@ class CNN:
             raise TypeError('Threshold must be a float between -1.0 and 1.0')
         if thresh < -1.0 or thresh > 1.0:
             raise ValueError('Threshold must be a float between -1.0 and 1.0')
-
-    def _searcher(self, results: Dict, image_ids, scores, threshold, cos_scores: List) -> None:
-        """
-        Perform image encoding on a sublist passed in by encode_images multiprocessing part.
-
-        Args:
-            hash_dict: Global dictionary that gets shared by all processes
-            filenames: Sublist of file names on which hashes are to be generated.
-        """
-        # print(cos_scores)
-        for i, j in enumerate(cos_scores):
-            duplicates_bool = (j >= threshold) & (j < 2)
-            # print(duplicates_bool)
-
-            if scores:
-                tmp = np.array([*zip(image_ids, j)], dtype=object)
-                duplicates = list(map(tuple, tmp[duplicates_bool]))
-
-            else:
-                duplicates = list(image_ids[duplicates_bool])
-                # print(duplicates)
-            results[image_ids[i]] = duplicates
-            print(results)
 
     def _find_duplicates_dict(
         self,

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -2,6 +2,10 @@ import os
 from pathlib import PosixPath, Path
 from typing import Dict, List, Optional
 
+from imagededup.handlers.search.retrieval import HashEval
+from imagededup.utils.image_utils import load_image, preprocess_image
+from imagededup.utils.general_utils import get_files_to_remove, save_json
+import os
 import pywt
 import numpy as np
 from scipy.fftpack import dct
@@ -13,7 +17,7 @@ from imagededup.utils.image_utils import load_image, preprocess_image
 
 from pathlib import PosixPath, Path
 from typing import Dict, List, Optional
-from imagededup.utils.general_utils import parallelize
+from imagededup.utils.general_utils import parallelise
 
 
 """
@@ -99,20 +103,6 @@ class Hashing:
             raise ValueError('Please provide either image file path or image array!')
 
         return self._hash_func(image_pp) if isinstance(image_pp, np.ndarray) else None
-
-    def _encoder(self, hash_dict: Dict, filenames: List) -> None:
-        """
-        Perform image encoding on a sublist passed in by encode_images multiprocessing part.
-
-        Args:
-            hash_dict: Global dictionary that gets shared by all processes
-            filenames: Sublist of file names on which hashes are to be generated.
-        """
-        for _file in filenames:
-            encoding = self.encode_image(image_file=_file)
-
-            if encoding:
-                hash_dict[_file.name] = encoding
 
     def encode_images(self, image_dir=None):
         """

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -121,14 +121,16 @@ class Hashing:
         image_dir = Path(image_dir)
 
         files = [
-            i.absolute() for i in image_dir.glob("*") if not i.name.startswith(".")
+            i.absolute() for i in image_dir.glob('*') if not i.name.startswith('.')
         ]  # ignore hidden files
 
         print(f'Start: Calculating hashes...')
 
         hashes = parallelise(self.encode_image, files)
         hash_initial_dict = dict(zip([f.name for f in files], hashes))
-        hash_dict = {k: v for k, v in hash_initial_dict.items() if v}  # To ignore None (returned if some probelm with image file)
+        hash_dict = {
+            k: v for k, v in hash_initial_dict.items() if v
+        }  # To ignore None (returned if some probelm with image file)
 
         print(f'End: Calculating hashes!')
         return hash_dict
@@ -193,7 +195,8 @@ class Hashing:
             queries=encoding_map,
             distance_function=self.hamming_distance,
             threshold=max_distance_threshold,
-            search_method='bktree')
+            search_method='bktree',
+        )
 
         print('End: Evaluating hamming distances for getting duplicates')
 
@@ -295,7 +298,7 @@ class Hashing:
                 outfile=outfile,
             )
         else:
-            raise ValueError("Provide either an image directory or encodings!")
+            raise ValueError('Provide either an image directory or encodings!')
         return result
 
     def find_duplicates_to_remove(

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -96,6 +96,15 @@ class Hashing:
 
         return self._hash_func(image_pp) if isinstance(image_pp, np.ndarray) else None
 
+    def _encoder(self, hash_dict: Dict, filenames: List) -> None:
+        # print(filenames)
+        for _file in filenames:
+            print(_file)
+            encoding = self.encode_image(image_file=_file)
+
+            if encoding:
+                hash_dict[_file.name] = encoding
+
     def encode_images(self, image_dir=None):
         """
         Generate hashes for all images in a given directory of images.

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -128,7 +128,7 @@ class Hashing:
 
         hashes = parallelise(self.encode_image, files)
         hash_initial_dict = dict(zip([f.name for f in files], hashes))
-        hash_dict = {k: v for k, v in hash_initial_dict.items() if v}
+        hash_dict = {k: v for k, v in hash_initial_dict.items() if v}  # To ignore None (returned if some probelm with image file)
 
         print(f'End: Calculating hashes!')
         return hash_dict

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -1,7 +1,3 @@
-from imagededup.handlers.search.retrieval import HashEval
-from imagededup.utils.image_utils import load_image, preprocess_image
-from imagededup.utils.general_utils import get_files_to_remove, save_json
-
 import os
 from pathlib import PosixPath, Path
 from typing import Dict, List, Optional
@@ -14,12 +10,6 @@ from scipy.fftpack import dct
 from imagededup.handlers.search.retrieval import HashEval
 from imagededup.utils.general_utils import get_files_to_remove, save_json, parallelise
 from imagededup.utils.image_utils import load_image, preprocess_image
-from imagededup.utils.logger import return_logger
-
-
-from pathlib import PosixPath, Path
-from typing import Dict, List, Optional
-from imagededup.utils.general_utils import parallelise
 
 
 """

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -2,22 +2,14 @@ import os
 from pathlib import PosixPath, Path
 from typing import Dict, List, Optional
 
-from imagededup.handlers.search.retrieval import HashEval
-from imagededup.utils.image_utils import load_image, preprocess_image
-from imagededup.utils.general_utils import get_files_to_remove, save_json
-import os
 import pywt
 import numpy as np
 from scipy.fftpack import dct
 
 
 from imagededup.handlers.search.retrieval import HashEval
-from imagededup.utils.general_utils import get_files_to_remove, save_json
+from imagededup.utils.general_utils import get_files_to_remove, save_json, parallelise
 from imagededup.utils.image_utils import load_image, preprocess_image
-
-from pathlib import PosixPath, Path
-from typing import Dict, List, Optional
-from imagededup.utils.general_utils import parallelise
 
 
 """

--- a/imagededup/methods/hashing.py
+++ b/imagededup/methods/hashing.py
@@ -8,8 +8,12 @@ from scipy.fftpack import dct
 
 
 from imagededup.handlers.search.retrieval import HashEval
-from imagededup.utils.general_utils import get_files_to_remove, save_json, parallelise
+from imagededup.utils.general_utils import get_files_to_remove, save_json
 from imagededup.utils.image_utils import load_image, preprocess_image
+
+from pathlib import PosixPath, Path
+from typing import Dict, List, Optional
+from imagededup.utils.general_utils import parallelize
 
 
 """
@@ -97,9 +101,14 @@ class Hashing:
         return self._hash_func(image_pp) if isinstance(image_pp, np.ndarray) else None
 
     def _encoder(self, hash_dict: Dict, filenames: List) -> None:
-        # print(filenames)
+        """
+        Perform image encoding on a sublist passed in by encode_images multiprocessing part.
+
+        Args:
+            hash_dict: Global dictionary that gets shared by all processes
+            filenames: Sublist of file names on which hashes are to be generated.
+        """
         for _file in filenames:
-            print(_file)
             encoding = self.encode_image(image_file=_file)
 
             if encoding:

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -13,7 +13,6 @@ from typing import Dict, List
 
 from imagededup.utils.logger import return_logger
 
-
 logger = return_logger(__name__, os.getcwd())
 
 
@@ -55,16 +54,31 @@ def save_json(results: Dict, filename: str) -> None:
     logger.info('End: Saving duplicates as json!')
 
 
-def parallelize(target_function: FunctionType, all_tasks: List, args_target_function: Tuple = ()):
-    from multiprocessing import Manager, Process, cpu_count
-    manager = Manager()  # used to share the hash dictionary across different processes
-    result = manager.dict()  # Only works for dictionary returns
-    chunks = [i for i in np.array_split(all_tasks, cpu_count())]  # Each process gets a
-    # sublist of keys
+# def parallelize(target_function: FunctionType, all_tasks: List, args_target_function: Tuple = ()):
+#     manager = Manager()  # used to share the global variable (result dictionary) across different processes
+#     result = manager.dict()  # Only works for dictionary returns
+#     chunks = [i for i in np.array_split(all_tasks, cpu_count())]  # Each process gets a
+#     # sublist of tasks
+#
+#     args_in = (result, *args_target_function)
+#     job = [Process(target=target_function, args=(*args_in, sublist)) for sublist in chunks]
+#     _ = [p.start() for p in job]
+#     _ = [p.join() for p in job]
+#     return result
 
-    args_in = (result, *args_target_function)
-    job = [Process(target=target_function, args=(*args_in, sublist)) for sublist in
-           chunks]
-    _ = [p.start() for p in job]
-    _ = [p.join() for p in job]
-    return result
+
+def parallelise(function, data):
+    vcore_count = cpu_count()
+    chunksize = len(data) // vcore_count
+
+    if chunksize == 0:
+        n_proc = 1
+        chunksize = 1
+    else:
+        n_proc = vcore_count
+
+    pool = Pool(processes=n_proc)
+    results = list(tqdm.tqdm(pool.imap(function, data, 1), total=len(data)))
+    pool.close()
+    pool.join()
+    return results

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -1,8 +1,13 @@
 import os
+
 import json
 from typing import Dict, List
 
 from imagededup.utils.logger import return_logger
+
+import multiprocessing
+import tqdm
+
 
 logger = return_logger(__name__, os.getcwd())
 
@@ -43,3 +48,13 @@ def save_json(results: Dict, filename: str) -> None:
     with open(filename, 'w') as f:
         json.dump(results, f, indent=2, sort_keys=True)
     logger.info('End: Saving duplicates as json!')
+
+
+def parallelise(function, data):
+    num_process = multiprocessing.cpu_count()
+    chunk_len = len(data) // num_process
+    pool = multiprocessing.Pool(processes=num_process)
+    results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
+    pool.close()
+    pool.join()
+    return results

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -7,6 +7,8 @@ import tqdm
 
 
 import json
+import multiprocessing
+import tqdm
 from typing import Dict, List
 
 from imagededup.utils.logger import return_logger
@@ -56,31 +58,11 @@ def save_json(results: Dict, filename: str) -> None:
     logger.info('End: Saving duplicates as json!')
 
 
-# def parallelize(target_function: FunctionType, all_tasks: List, args_target_function: Tuple = ()):
-#     manager = Manager()  # used to share the global variable (result dictionary) across different processes
-#     result = manager.dict()  # Only works for dictionary returns
-#     chunks = [i for i in np.array_split(all_tasks, cpu_count())]  # Each process gets a
-#     # sublist of tasks
-#
-#     args_in = (result, *args_target_function)
-#     job = [Process(target=target_function, args=(*args_in, sublist)) for sublist in chunks]
-#     _ = [p.start() for p in job]
-#     _ = [p.join() for p in job]
-#     return result
-
-
 def parallelise(function, data):
-    vcore_count = cpu_count()
-    chunksize = len(data) // vcore_count
-
-    if chunksize == 0:
-        n_proc = 1
-        chunksize = 1
-    else:
-        n_proc = vcore_count
-
-    pool = Pool(processes=n_proc)
-    results = list(tqdm.tqdm(pool.imap(function, data, 1), total=len(data)))
+    num_process = multiprocessing.cpu_count()
+    chunk_len = len(data) // num_process
+    pool = multiprocessing.Pool(processes=num_process)
+    results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
     pool.close()
     pool.join()
     return results

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -1,17 +1,9 @@
-import os
-import numpy as np
-from types import FunctionType
-from typing import Tuple
-from multiprocessing import Manager, Process, cpu_count, Pool
-import tqdm
-
-
 import json
+import tqdm
 from typing import Dict, List
 
-from imagededup.utils.logger import return_logger
-
-# logger = return_logger(__name__, os.getcwd())
+from multiprocessing import cpu_count, Pool
+from typing import Callable
 
 
 def get_files_to_remove(duplicates: Dict[str, List]) -> List:
@@ -52,7 +44,7 @@ def save_json(results: Dict, filename: str) -> None:
     print('End: Saving duplicates as json!')
 
 
-def parallelise(function, data):
+def parallelise(function: Callable, data: List) -> List:
     pool = Pool(processes=cpu_count())
     results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
     pool.close()

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -13,9 +13,6 @@ from typing import Dict, List
 
 from imagededup.utils.logger import return_logger
 
-import multiprocessing
-import tqdm
-
 
 logger = return_logger(__name__, os.getcwd())
 
@@ -57,3 +54,17 @@ def save_json(results: Dict, filename: str) -> None:
         json.dump(results, f, indent=2, sort_keys=True)
     logger.info('End: Saving duplicates as json!')
 
+
+def parallelize(target_function: FunctionType, all_tasks: List, args_target_function: Tuple = ()):
+    from multiprocessing import Manager, Process, cpu_count
+    manager = Manager()  # used to share the hash dictionary across different processes
+    result = manager.dict()  # Only works for dictionary returns
+    chunks = [i for i in np.array_split(all_tasks, cpu_count())]  # Each process gets a
+    # sublist of keys
+
+    args_in = (result, *args_target_function)
+    job = [Process(target=target_function, args=(*args_in, sublist)) for sublist in
+           chunks]
+    _ = [p.start() for p in job]
+    _ = [p.join() for p in job]
+    return result

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -7,13 +7,11 @@ import tqdm
 
 
 import json
-import multiprocessing
-import tqdm
 from typing import Dict, List
 
 from imagededup.utils.logger import return_logger
 
-logger = return_logger(__name__, os.getcwd())
+# logger = return_logger(__name__, os.getcwd())
 
 
 def get_files_to_remove(duplicates: Dict[str, List]) -> List:
@@ -48,10 +46,10 @@ def save_json(results: Dict, filename: str) -> None:
         results: Dictionary of results to be saved.
         filename: Name of the file to be saved.
     """
-    logger.info('Start: Saving duplicates as json!')
+    print('Start: Saving duplicates as json!')
     with open(filename, 'w') as f:
         json.dump(results, f, indent=2, sort_keys=True)
-    logger.info('End: Saving duplicates as json!')
+    print('End: Saving duplicates as json!')
 
 
 # def parallelize(target_function: FunctionType, all_tasks: List, args_target_function: Tuple = ()):

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -52,31 +52,9 @@ def save_json(results: Dict, filename: str) -> None:
     print('End: Saving duplicates as json!')
 
 
-# def parallelize(target_function: FunctionType, all_tasks: List, args_target_function: Tuple = ()):
-#     manager = Manager()  # used to share the global variable (result dictionary) across different processes
-#     result = manager.dict()  # Only works for dictionary returns
-#     chunks = [i for i in np.array_split(all_tasks, cpu_count())]  # Each process gets a
-#     # sublist of tasks
-#
-#     args_in = (result, *args_target_function)
-#     job = [Process(target=target_function, args=(*args_in, sublist)) for sublist in chunks]
-#     _ = [p.start() for p in job]
-#     _ = [p.join() for p in job]
-#     return result
-
-
 def parallelise(function, data):
-    vcore_count = cpu_count()
-    chunksize = len(data) // vcore_count
-
-    if chunksize == 0:
-        n_proc = 1
-        chunksize = 1
-    else:
-        n_proc = vcore_count
-
-    pool = Pool(processes=n_proc)
-    results = list(tqdm.tqdm(pool.imap(function, data, 1), total=len(data)))
+    pool = Pool(processes=cpu_count())
+    results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
     pool.close()
     pool.join()
     return results

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -1,5 +1,6 @@
 import os
 
+
 import json
 from typing import Dict, List
 
@@ -49,12 +50,3 @@ def save_json(results: Dict, filename: str) -> None:
         json.dump(results, f, indent=2, sort_keys=True)
     logger.info('End: Saving duplicates as json!')
 
-
-def parallelise(function, data):
-    num_process = multiprocessing.cpu_count()
-    chunk_len = len(data) // num_process
-    pool = multiprocessing.Pool(processes=num_process)
-    results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
-    pool.close()
-    pool.join()
-    return results

--- a/imagededup/utils/general_utils.py
+++ b/imagededup/utils/general_utils.py
@@ -57,12 +57,3 @@ def save_json(results: Dict, filename: str) -> None:
         json.dump(results, f, indent=2, sort_keys=True)
     logger.info('End: Saving duplicates as json!')
 
-
-def parallelise(function, data):
-    num_process = multiprocessing.cpu_count()
-    chunk_len = len(data) // num_process
-    pool = multiprocessing.Pool(processes=num_process)
-    results = list(tqdm.tqdm(pool.imap(function, data), total=len(data)))
-    pool.close()
-    pool.join()
-    return results

--- a/tests/test_bktree.py
+++ b/tests/test_bktree.py
@@ -7,7 +7,9 @@ from imagededup.handlers.search.bktree import BKTree, BkTreeNode
 
 
 def initialize_for_bktree():
-    hash_dict = OrderedDict({'a': '9', 'b': 'D', 'c': 'A', 'd': 'F', 'e': '2', 'f': '6', 'g': '7', 'h': 'E'})
+    hash_dict = OrderedDict(
+        {'a': '9', 'b': 'D', 'c': 'A', 'd': 'F', 'e': '2', 'f': '6', 'g': '7', 'h': 'E'}
+    )
     dist_func = Hashing.hamming_distance
     return hash_dict, dist_func
 
@@ -19,6 +21,7 @@ def test_bktreenode_correct_initialization():
     assert node.node_value == '1aef'
     assert node.parent_name is None
     assert len(node.children) == 0
+
 
 # test BKTree class
 
@@ -37,7 +40,9 @@ def test_insert_tree_collision():
     # initialize root node, add 1 new node and enter another node with same distance from root, check it goes not as
     # root's child but the other node's child
     _, dist_func = initialize_for_bktree()
-    hash_dict = OrderedDict({'a': '9', 'b': 'D', 'c': '8'}) # to guarantee that 'a' is the root of the tree
+    hash_dict = OrderedDict(
+        {'a': '9', 'b': 'D', 'c': '8'}
+    )  # to guarantee that 'a' is the root of the tree
     bk = BKTree(hash_dict, dist_func)
     assert bk.ROOT == 'a'
     assert len(bk.dict_all[bk.ROOT].children) == 1
@@ -48,7 +53,9 @@ def test_insert_tree_different_nodes():
     # initialize root node, add 1 new node and enter another node with different distance from root, check it goes as
     # root's child and not as the other node's child
     _, dist_func = initialize_for_bktree()
-    hash_dict = OrderedDict({'a': '9', 'b': 'D', 'c': 'F'})  # to guarantee that 'a' is the root of the tree
+    hash_dict = OrderedDict(
+        {'a': '9', 'b': 'D', 'c': 'F'}
+    )  # to guarantee that 'a' is the root of the tree
     bk = BKTree(hash_dict, dist_func)
     assert bk.ROOT == 'a'
     assert len(bk.dict_all[bk.ROOT].children) == 2
@@ -59,7 +66,9 @@ def test_insert_tree_check_distance():
     # initialize root node, add 1 new node and enter another node with different distance from root, check that the
     # distance recorded in the root's children dictionary is as expected
     _, dist_func = initialize_for_bktree()
-    hash_dict = OrderedDict({'a': '9', 'b': 'D', 'c': 'F'})  # to guarantee that 'a' is the root of the tree
+    hash_dict = OrderedDict(
+        {'a': '9', 'b': 'D', 'c': 'F'}
+    )  # to guarantee that 'a' is the root of the tree
     bk = BKTree(hash_dict, dist_func)
     assert bk.ROOT == 'a'
     assert bk.dict_all[bk.ROOT].children['b'] == 1
@@ -73,7 +82,9 @@ def test_construct_tree():
     # check root
     assert bk.ROOT == 'a'
     # check that expected leaf nodes have no children (they're actually leaf nodes)
-    leaf_nodes = set([k for k in bk.dict_all.keys() if len(bk.dict_all[k].children)==0])
+    leaf_nodes = set(
+        [k for k in bk.dict_all.keys() if len(bk.dict_all[k].children) == 0]
+    )
     expected_leaf_nodes = set(['b', 'd', 'f', 'h'])
     assert leaf_nodes == expected_leaf_nodes
     # check that root node ('a') has 4 children
@@ -124,7 +135,9 @@ def test_get_next_candidates_valid():
     bk = BKTree(hash_dict, dist_func)
     assert bk.ROOT == 'a'
     query = '5'
-    candidates, validity, dist = bk._get_next_candidates(query, bk.dict_all[bk.ROOT], tolerance=2)
+    candidates, validity, dist = bk._get_next_candidates(
+        query, bk.dict_all[bk.ROOT], tolerance=2
+    )
     candidates = set(candidates)
     assert candidates <= set(['b', 'c', 'e', 'f'])
     assert validity
@@ -152,5 +165,3 @@ def test_tolerance_affects_retrievals():
     candidates, _, _ = bk._get_next_candidates(query, bk.dict_all[bk.ROOT], tolerance=2)
     high_tolerance_candidate_len = len(candidates)
     assert high_tolerance_candidate_len > low_tolerance_candidate_len
-
-

--- a/tests/test_brute_force.py
+++ b/tests/test_brute_force.py
@@ -5,7 +5,9 @@ from imagededup.methods.hashing import Hashing
 
 
 def initialize():
-    hash_dict = OrderedDict({'a': '9', 'b': 'D', 'c': 'A', 'd': 'F', 'e': '2', 'f': '6', 'g': '7', 'h': 'E'})
+    hash_dict = OrderedDict(
+        {'a': '9', 'b': 'D', 'c': 'A', 'd': 'F', 'e': '2', 'f': '6', 'g': '7', 'h': 'E'}
+    )
     dist_func = Hashing.hamming_distance
     return hash_dict, dist_func
 
@@ -24,4 +26,6 @@ def test_tolerance_value_effect():
     query = '5'
     valid_retrievals_2 = bf.search(query, tol=2)
     valid_retrievals_3 = bf.search(query, tol=3)
-    assert set([i[0] for i in valid_retrievals_2]) != set([i[0] for i in valid_retrievals_3])
+    assert set([i[0] for i in valid_retrievals_2]) != set(
+        [i[0] for i in valid_retrievals_3]
+    )

--- a/tests/test_classification.py
+++ b/tests/test_classification.py
@@ -107,7 +107,8 @@ def test_classification_metrics(mocker):
     make_all_unique_possible_pairs_mocker.return_value = all_possible_pairs_ret
 
     make_positive_duplicate_pairs_mocker = mocker.patch(
-        'imagededup.handlers.metrics.classification._make_positive_duplicate_pairs')
+        'imagededup.handlers.metrics.classification._make_positive_duplicate_pairs'
+    )
     make_positive_duplicate_pairs_mocker.return_value = (
         ground_truth_pairs_ret,
         retrieved_pairs_ret,
@@ -142,7 +143,7 @@ def test_classification_metrics_integrated():
         'precision': np.array([0.5, 1.0]),
         'recall': np.array([1.0, 0.5]),
         'f1_score': np.array([0.66666667, 0.66666667]),
-        'support': np.array([2, 4])
+        'support': np.array([2, 4]),
     }
     metrics = classification_metrics(ground_truth, retrieved)
     assert isinstance(metrics, dict)
@@ -150,4 +151,3 @@ def test_classification_metrics_integrated():
     for k, v in metrics.items():
         assert isinstance(v, np.ndarray)
         np.testing.assert_almost_equal(metrics[k], expected_return[k])
-

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -64,7 +64,9 @@ def test__data_generator():
 def test_on_epoch_end_1():
     generator.on_epoch_end()
 
-    assert generator.valid_image_files == sorted([x for x in IMAGE_DIR.glob('*') if x.is_file()])
+    assert generator.valid_image_files == sorted(
+        [x for x in IMAGE_DIR.glob('*') if x.is_file()]
+    )
 
 
 def test_on_epoch_end_2():

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -25,7 +25,7 @@ def test__transpose_checker():
         '1': ['2', '3', '4'],
         '2': ['1', '3'],
         '3': ['1', '2'],
-        '4': []
+        '4': [],
     }
     with pytest.raises(AssertionError):
         _transpose_checker(mapping_non_transpose)
@@ -55,10 +55,10 @@ def test__check_map_correctness_different_keys():
 def test_default_returns_all_metrics(mocker):
     ground_truth_map, retrieve_map = return_ground_all_correct_retrievals()
     get_all_metrics_mocker = mocker.patch(
-        "imagededup.evaluation.evaluation.get_all_metrics"
+        'imagededup.evaluation.evaluation.get_all_metrics'
     )
     classification_metrics_mocker = mocker.patch(
-        "imagededup.evaluation.evaluation.classification_metrics"
+        'imagededup.evaluation.evaluation.classification_metrics'
     )
     classification_metrics_mocker = mocker.patch(
         'imagededup.evaluation.evaluation.classification_metrics'
@@ -73,13 +73,13 @@ def test_default_returns_all_metrics(mocker):
 def test_wrong_metric_raises_valueerror():
     ground_truth_map, retrieve_map = return_ground_all_correct_retrievals()
     with pytest.raises(ValueError):
-        evaluate(ground_truth_map, retrieve_map, metric="bla")
+        evaluate(ground_truth_map, retrieve_map, metric='bla')
 
 
-@pytest.mark.parametrize("metric_name", ["map", "ndcg", "jaccard"])
+@pytest.mark.parametrize('metric_name', ['map', 'ndcg', 'jaccard'])
 def test_correct_call_to_mean_metric(mocker, metric_name):
     ground_truth_map, retrieve_map = return_ground_all_correct_retrievals()
-    mean_metric_mocker = mocker.patch("imagededup.evaluation.evaluation.mean_metric")
+    mean_metric_mocker = mocker.patch('imagededup.evaluation.evaluation.mean_metric')
     evaluate(ground_truth_map, retrieve_map, metric=metric_name)
     mean_metric_mocker.assert_called_once_with(
         ground_truth_map, retrieve_map, metric=metric_name
@@ -100,7 +100,7 @@ def test_correct_call_to_classification_metric(mocker):
 @pytest.mark.parametrize('metric_name', ['MAP', 'Ndcg', 'JacCard'])
 def test_correct_call_to_mean_metric_mixed_cases(mocker, metric_name):
     ground_truth_map, retrieve_map = return_ground_all_correct_retrievals()
-    mean_metric_mocker = mocker.patch("imagededup.evaluation.evaluation.mean_metric")
+    mean_metric_mocker = mocker.patch('imagededup.evaluation.evaluation.mean_metric')
     evaluate(ground_truth_map, retrieve_map, metric=metric_name)
     mean_metric_mocker.assert_called_once_with(
         ground_truth_map, retrieve_map, metric=metric_name.lower()
@@ -141,7 +141,7 @@ def test_correct_values_classification():
         'precision': np.array([0.5, 1.0]),
         'recall': np.array([1.0, 0.5]),
         'f1_score': np.array([0.66666667, 0.66666667]),
-        'support': np.array([2, 4])
+        'support': np.array([2, 4]),
     }
     score = evaluate(ground_truth, retrieved, metric='classification')
     assert isinstance(score, dict)

--- a/tests/test_general_utils.py
+++ b/tests/test_general_utils.py
@@ -5,6 +5,7 @@ from imagededup.utils import general_utils
 
 def test_get_files_to_remove():
     from collections import OrderedDict
+
     dict_a = OrderedDict({'1': ['2'], '2': ['1', '3'], '3': ['4'], '4': ['3'], '5': []})
     dups_to_remove = general_utils.get_files_to_remove(dict_a)
     assert set(dups_to_remove) == set(['2', '4'])

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -2,8 +2,8 @@ import os
 from pathlib import Path
 from PIL import Image
 
-import numpy as np
 import pytest
+import numpy as np
 
 from imagededup.methods.hashing import Hashing, PHash, DHash, AHash, WHash
 
@@ -149,35 +149,13 @@ def test_encode_image_accepts_non_posixpath(
 
 @pytest.fixture
 def mocker_encode_image(mocker):
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Fix tests for hashing with multiprocessing.
     mocker.patch(
         'imagededup.methods.hashing.parallelise',
         return_value='123456789ABCDEFA'
     )
-<<<<<<< HEAD
-=======
-    return mocker.patch('imagededup.methods.hashing.Hashing.encode_image', return_value='123456789ABCDEFA')
-
-
-def test__encoder(hasher, mocker_encode_image):
-    hash_dict = {}
-    filenames = [
-        i.absolute() for i in PATH_IMAGE_DIR.glob('*') if not i.name.startswith('.')
-    ]
-    hasher._encoder(hash_dict, filenames)
-    mocker_encode_image.assert_called_with(image_file=filenames[-1])
 
 
 # encode_images
->>>>>>> Add multiprocessing for hash generation. Works and provides speedup.
-
-=======
-
-# encode_images
->>>>>>> Fix tests for hashing with multiprocessing.
 
 def test_encode_images_accepts_valid_posixpath(hasher, mocker_encode_image):
     assert len(hasher.encode_images(PATH_IMAGE_DIR)) == 6  # 6 files in the directory

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -45,7 +45,6 @@ def test__array_to_hash(hasher):
     assert hasher._array_to_hash(hash_mat) == '9191fa'
 
 
-
 def test__check_hamming_distance_bounds_input_not_int(hasher):
     with pytest.raises(TypeError):
         hasher._check_hamming_distance_bounds(thresh=1.0)
@@ -147,15 +146,16 @@ def test_encode_image_accepts_non_posixpath(
 
 # _encoder
 
+
 @pytest.fixture
 def mocker_encode_image(mocker):
     mocker.patch(
-        'imagededup.methods.hashing.parallelise',
-        return_value='123456789ABCDEFA'
+        'imagededup.methods.hashing.parallelise', return_value='123456789ABCDEFA'
     )
 
 
 # encode_images
+
 
 def test_encode_images_accepts_valid_posixpath(hasher, mocker_encode_image):
     assert len(hasher.encode_images(PATH_IMAGE_DIR)) == 6  # 6 files in the directory
@@ -211,7 +211,8 @@ def test__find_duplicates_dict_outfile_none(hasher, mocker):
         queries=encoding_map,
         distance_function=Hashing.hamming_distance,
         threshold=threshold,
-        search_method='bktree')
+        search_method='bktree',
+    )
     hasheval_mocker.return_value.retrieve_results.assert_called_once_with(scores=scores)
     save_json_mocker.assert_not_called()
 
@@ -238,7 +239,8 @@ def test__find_duplicates_dict_outfile_true(hasher, mocker):
         queries=encoding_map,
         distance_function=Hashing.hamming_distance,
         threshold=threshold,
-        search_method='bktree')
+        search_method='bktree',
+    )
     hasheval_mocker.return_value.retrieve_results.assert_called_once_with(scores=scores)
     save_json_mocker.assert_called_once_with(
         hasheval_mocker.return_value.retrieve_results.return_value, outfile
@@ -255,7 +257,7 @@ def test__find_duplicates_dir(hasher, mocker):
     outfile = True
     ret_val_find_dup_dict = {
         'filename.jpg': [('dup1.jpg', 3)],
-        'filename2.jpg': [('dup2.jpg', 10)]
+        'filename2.jpg': [('dup2.jpg', 10)],
     }
     encode_images_mocker = mocker.patch(
         'imagededup.methods.hashing.Hashing.encode_images', return_value=encoding_map

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -150,10 +150,14 @@ def test_encode_image_accepts_non_posixpath(
 @pytest.fixture
 def mocker_encode_image(mocker):
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Fix tests for hashing with multiprocessing.
     mocker.patch(
-        'imagededup.methods.hashing.Hashing.encode_image',
+        'imagededup.methods.hashing.parallelise',
         return_value='123456789ABCDEFA'
     )
+<<<<<<< HEAD
 =======
     return mocker.patch('imagededup.methods.hashing.Hashing.encode_image', return_value='123456789ABCDEFA')
 
@@ -170,13 +174,16 @@ def test__encoder(hasher, mocker_encode_image):
 # encode_images
 >>>>>>> Add multiprocessing for hash generation. Works and provides speedup.
 
+=======
+
+# encode_images
+>>>>>>> Fix tests for hashing with multiprocessing.
 
 def test_encode_images_accepts_valid_posixpath(hasher, mocker_encode_image):
     assert len(hasher.encode_images(PATH_IMAGE_DIR)) == 6  # 6 files in the directory
 
 
 def test_encode_images_accepts_non_posixpath(hasher, mocker_encode_image):
-    print(PATH_IMAGE_DIR_STRING)
     assert len(hasher.encode_images(PATH_IMAGE_DIR_STRING)) == 6
 
 
@@ -189,7 +196,7 @@ def test_encode_images_return_vals(hasher, mocker_encode_image):
     encoded_val = '123456789ABCDEFA'
     hashes = hasher.encode_images(PATH_IMAGE_DIR)
     assert isinstance(hashes, dict)
-    assert list(hashes.values())[0] == encoded_val
+    assert list(hashes.values())[0] == encoded_val[0]
     assert PATH_SINGLE_IMAGE.name in hashes.keys()
 
 

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -145,15 +145,30 @@ def test_encode_image_accepts_non_posixpath(
     np.testing.assert_array_equal(ret_val, mocker_hash_func.call_args[0][0])
 
 
-# encode_images
-
+# _encoder
 
 @pytest.fixture
 def mocker_encode_image(mocker):
+<<<<<<< HEAD
     mocker.patch(
         'imagededup.methods.hashing.Hashing.encode_image',
         return_value='123456789ABCDEFA'
     )
+=======
+    return mocker.patch('imagededup.methods.hashing.Hashing.encode_image', return_value='123456789ABCDEFA')
+
+
+def test__encoder(hasher, mocker_encode_image):
+    hash_dict = {}
+    filenames = [
+        i.absolute() for i in PATH_IMAGE_DIR.glob('*') if not i.name.startswith('.')
+    ]
+    hasher._encoder(hash_dict, filenames)
+    mocker_encode_image.assert_called_with(image_file=filenames[-1])
+
+
+# encode_images
+>>>>>>> Add multiprocessing for hash generation. Works and provides speedup.
 
 
 def test_encode_images_accepts_valid_posixpath(hasher, mocker_encode_image):

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -95,4 +95,3 @@ def test_load_image_all_inputs_correct():
     assert np.issubdtype(
         np.uint8, loaded_image.dtype
     )  # return numpy array dtype is uint8
-

--- a/tests/test_information_retrieval.py
+++ b/tests/test_information_retrieval.py
@@ -1,11 +1,8 @@
-from imagededup.handlers.metrics.information_retrieval import *
-from pathlib import Path
 import pickle
 import pytest
+from pathlib import Path
 
-"""Run from project root with: python -m pytest -vs tests/test_information_retrieval.py 
---cov=imagededup.handlers.metrics.information_retrieval"""
-
+from imagededup.handlers.metrics.information_retrieval import *
 
 p = Path(__file__)
 

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -150,5 +150,3 @@ def test_results_sorted_in_ascending_distance_order():
     distances = [i[1] for v in result.values() for i in v]
 
     assert sorted(distances, reverse=False) == distances
-
-

--- a/tests/test_retrieval.py
+++ b/tests/test_retrieval.py
@@ -74,6 +74,7 @@ def test_result_consistency_across_search_methods():
     brute_force_result = HashEval(
         db, query, HAMMING_DISTANCE_FUNCTION, search_method='brute_force'
     ).retrieve_results()
+
     bktree_result = HashEval(db, query, HAMMING_DISTANCE_FUNCTION).retrieve_results()
     assert brute_force_result == bktree_result
 
@@ -112,6 +113,7 @@ def test_no_self_retrieval():
     brute_res = HashEval(
         db, query, HAMMING_DISTANCE_FUNCTION, search_method='brute_force'
     ).retrieve_results()
+
     bktree_res = HashEval(db, query, HAMMING_DISTANCE_FUNCTION).retrieve_results()
     assert len(brute_res['ukbench09268.jpg']) == 0
     assert len(bktree_res['ukbench09268.jpg']) == 0
@@ -128,13 +130,13 @@ def test_max_hamming_threshold_not_violated():
         'ukbench09268_2.jpg': 'ac9c72f8e1c2c448',
     }
     result = HashEval(
-        db, query, HAMMING_DISTANCE_FUNCTION, search_method='brute_force'
+        db, query, HAMMING_DISTANCE_FUNCTION, search_method='bktree'
     ).retrieve_results(scores=True)
     distances = [i[1] for v in result.values() for i in v]
     assert max(distances) < 5  # 5 is the default threshold value
 
 
-def test_results_sorted_in_descending_distance_order():
+def test_results_sorted_in_ascending_distance_order():
     query = {'ukbench00120.jpg': '2b69707551f1b87a'}
     db = {
         'ukbench00120_hflip.jpg': '2b69707551f1b87f',
@@ -143,9 +145,10 @@ def test_results_sorted_in_descending_distance_order():
         'ukbench09268_3.jpg': '2c89709251f1b870',
     }
     result = HashEval(
-        db, query, HAMMING_DISTANCE_FUNCTION, threshold=30, search_method='brute_force'
+        db, query, HAMMING_DISTANCE_FUNCTION, threshold=30, search_method='bktree'
     ).retrieve_results(scores=True)
     distances = [i[1] for v in result.values() for i in v]
 
     assert sorted(distances, reverse=False) == distances
+
 


### PR DESCRIPTION
Parellelize hash generation and retrieval through bktree.
Affected files are:

- imagededup.methods.hashing.py
- imagededup.utils.general_utils.py
- imagededup.handlers.search.retrieval.py
